### PR TITLE
[🐸 Frogbot] Update version of lodash to 4.17.23

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="74df63fc-1847-4506-8b74-d4f0b223cb9c" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "eyalk007"
+  }
+}]]></component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/eyalk007/big-npm.git",
+    "accountId": "26debb22-7357-45bd-b01b-461bc6349709"
+  }
+}]]></component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "customColor": "",
+  "associatedIndex": 8
+}]]></component>
+  <component name="ProjectId" id="38CFNDgWYG36MuBoy0W0eQ8QI87" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.go.formatter.settings.were.checked": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "main",
+    "kotlin-language-version-configured": "true",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "http.proxy",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-30f59d01ecdd-26cb7f24e5b0-intellij.indexing.shared.core-IU-253.29346.138" />
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-IU-253.29346.138" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="74df63fc-1847-4506-8b74-d4f0b223cb9c" name="Changes" comment="" />
+      <created>1768295604104</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1768295604104</updated>
+      <workItem from="1768295605118" duration="4817000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,34 +1,95 @@
-# npm-workspace-test
+# big-npm: NPM Regex Bug Test Project
 
-NPM workspace test project for Frogbot integration testing.
+## Purpose
 
-## Project Structure
+This project exposes a **critical bug** in the npm package handler's regex matching logic.
 
+## The Bug
+
+The npm handler searches for the **resolved version** from `package-lock.json` in the `package.json` file, but `package.json` typically contains **semver ranges**, not exact versions.
+
+### Example
+
+**package.json:**
+```json
+{
+  "dependencies": {
+    "axios": "^0.21.1"
+  }
+}
 ```
-npm-workspace-test/
-├── package.json (workspace root)
-└── packages/
-    ├── app-a/
-    │   └── package.json (lodash:4.17.15, axios:0.18.0)
-    └── app-b/
-        └── package.json (express:4.16.0, jquery:3.3.1)
+
+**package-lock.json:**
+```json
+{
+  "packages": {
+    "node_modules/axios": {
+      "version": "0.21.4"
+    }
+  }
+}
 ```
+
+**What happens:**
+1. JFrog engine scans `package-lock.json` and finds vulnerability in `axios@0.21.4`
+2. Engine reports: `ImpactedDependencyVersion = "0.21.4"`
+3. npm handler builds regex: `\s*"axios"\s*:\s*"[~^]?0\.21\.4"`
+4. Searches `package.json` for: `"axios": "0.21.4"` or `"axios": "^0.21.4"` or `"axios": "~0.21.4"`
+5. **❌ NO MATCH!** Because `package.json` has `"axios": "^0.21.1"`
+6. Error: `dependency 'axios' with version '0.21.4' not found in descriptor 'package.json' despite lock file evidence`
 
 ## Vulnerable Dependencies
 
-### App A (`packages/app-a/package.json`)
-- `lodash:4.17.15` - Multiple CVEs
-- `axios:0.18.0` - Known vulnerabilities
+This project contains the following vulnerable dependencies with semver ranges:
 
-### App B (`packages/app-b/package.json`)
-- `express:4.16.0` - Vulnerable version
-- `jquery:3.3.1` - Multiple XSS vulnerabilities
+| Package | package.json | Resolved in lock | Vulnerability |
+|---------|-------------|------------------|---------------|
+| `axios` | `^0.21.1` | `0.21.4` | High (SSRF, DoS, CSRF) |
+| `lodash` | `^4.17.19` | (check lock) | Various |
+| `minimist` | `~1.2.5` | (check lock) | Various |
+| `express` | `^4.17.0` | (check lock) | Various |
 
-## Testing
+## The Fix
 
-This project tests npm workspace support in Frogbot:
-- Multi-package detection
-- Correct working directory identification
-- package-lock.json handling across workspace
-- Minimal diffs (only version updates)
+The regex should search by **package name only**, not by version:
 
+**Current (broken):**
+```go
+npmDependencyRegexpPattern = `\s*"%s"\s*:\s*"[~^]?%s"`
+// Searches for: "axios": "[~^]?0.21.4"
+```
+
+**Fixed (like Maven):**
+```go
+npmDependencyRegexpPattern = `\s*"%s"\s*:\s*"[^"]+"`
+// Searches for: "axios": "<any version>"
+```
+
+## Frequency
+
+This bug affects **~85% of npm projects** because:
+- ✅ Most projects use semver ranges (`^`, `~`, `>=`)
+- ❌ Few projects pin exact versions
+
+## How to Test
+
+```bash
+# 1. Scan for vulnerabilities
+npm audit
+
+# 2. Run Frogbot (should fail with the regex bug)
+frogbot scan-repository
+
+# Expected error:
+# "dependency 'axios' with version '0.21.4' not found in descriptor"
+```
+
+## Comparison with MavenMaven's implementation doesn't have this bug because it searches by artifact coordinates only:```go
+// Maven regex (your implementation)
+pattern := regexp.MustCompile(
+    `(?s)(<groupId>` + regexp.QuoteMeta(groupId) + 
+    `</groupId>\s*<artifactId>` + regexp.QuoteMeta(artifactId) + 
+    `</artifactId>\s*<version>)[^<]+(</version>)`
+)
+// Matches ANY version: [^<]+
+```The npm handler should adopt the same strategy!

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^0.21.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.23",
         "minimist": "~1.2.5"
       },
       "devDependencies": {
+        "axios": "1.2.0",
         "express": "^4.17.0"
+      },
+      "peerDependencies": {
+        "axios": "^1.13.2"
       }
     },
     "node_modules/accepts": {
@@ -37,13 +41,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
+      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -112,6 +126,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -160,6 +187,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -243,6 +280,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -335,6 +388,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -349,6 +403,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -446,6 +517,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -511,9 +598,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -674,6 +761,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.1",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "Test project to expose npm regex bug where package.json has semver ranges but lock file has exact versions",
   "main": "index.js",
   "dependencies": {
-    "lodash": "^4.17.19",
-    "minimist": "~1.2.5",
-    "axios": "^0.21.1"
+    "axios": "^1.13.2",
+    "lodash": "^4.17.23",
+    "minimist": "~1.2.5"
   },
   "devDependencies": {
+    "axios": "1.2.0",
     "express": "^4.17.0"
+  },
+  "peerDependencies": {
+    "axios": "^1.13.2"
   }
 }


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>



### 📦 Vulnerable Dependencies

| Severity                | ID                  | Contextual Analysis                  | Dependency Path                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | ----------------------------------- |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2025-13465 | Not Covered | <details><summary><b>1 Direct</b></summary>lodash:4.17.21<br></details> |

### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Not Covered |
| **CVSS V3:** | - |
| **Dependency Path:** | <details><summary><b>lodash: 4.17.21 (Direct)</b></summary>Fix Version: 4.17.23<br></details> |

### Impact

Lodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the `_.unset` and `_.omit` functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes. 

The issue permits deletion of properties but does not allow overwriting their original behavior.  

### Patches

This issue is patched on 4.17.23.

---
<div align='center'>

[🐸 JFrog Frogbot](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>
